### PR TITLE
Intellisense: doc comments and inbox (server) terminology

### DIFF
--- a/mailosaur/mailosaur_client.py
+++ b/mailosaur/mailosaur_client.py
@@ -36,7 +36,7 @@ class MailosaurClient(object):
     :vartype files: ~mailosaur.operations.files_operations.FilesOperations
     :ivar messages: Operations for finding, retrieving, creating, and managing email and SMS messages.
     :vartype messages: ~mailosaur.operations.messages_operations.MessagesOperations
-    :ivar servers: Operations for creating and managing your Mailosaur servers (virtual inboxes).
+    :ivar servers: Operations for creating and managing your Mailosaur inboxes (servers).
     :vartype servers: ~mailosaur.operations.servers_operations.ServersOperations
     :ivar usage: Operations for inspecting account usage limits and recent transactional usage.
     :vartype usage: ~mailosaur.operations.usage_operations.UsageOperations

--- a/mailosaur/mailosaur_client.py
+++ b/mailosaur/mailosaur_client.py
@@ -23,10 +23,38 @@ from .models.mailosaur_exception import MailosaurException
 
 
 class MailosaurClient(object):
-    """ Main class to access Mailosaur.com api. """
+    """The Mailosaur client - the main entry point to the Mailosaur API.
+
+    Construct an instance with your API key (or set the ``MAILOSAUR_API_KEY``
+    environment variable), then use the operations namespaces (``messages``,
+    ``servers``, ``files``, ``devices``, ``analysis``, ``previews``, ``usage``)
+    to automate email and SMS testing.
+
+    :ivar analysis: Operations for analyzing email content and deliverability, including spam scoring.
+    :vartype analysis: ~mailosaur.operations.analysis_operations.AnalysisOperations
+    :ivar files: Operations for downloading attachments, EML source, and email preview screenshots.
+    :vartype files: ~mailosaur.operations.files_operations.FilesOperations
+    :ivar messages: Operations for finding, retrieving, creating, and managing email and SMS messages.
+    :vartype messages: ~mailosaur.operations.messages_operations.MessagesOperations
+    :ivar servers: Operations for creating and managing your Mailosaur servers (virtual inboxes).
+    :vartype servers: ~mailosaur.operations.servers_operations.ServersOperations
+    :ivar usage: Operations for inspecting account usage limits and recent transactional usage.
+    :vartype usage: ~mailosaur.operations.usage_operations.UsageOperations
+    :ivar devices: Operations for managing virtual security devices and retrieving their one-time passwords.
+    :vartype devices: ~mailosaur.operations.devices_operations.DevicesOperations
+    :ivar previews: Operations for discovering the email clients available for generating email previews.
+    :vartype previews: ~mailosaur.operations.previews_operations.PreviewsOperations
+    """
 
     def __init__(self, api_key=None, base_url="https://mailosaur.com/"):
-        """ Pass in your mailbox id and api key to authenticate """
+        """Returns an instance of the Mailosaur client.
+
+        :param api_key: Optional API key. Overrides the MAILOSAUR_API_KEY
+         environment variable if set.
+        :type api_key: str
+        :param base_url: Optionally overrides the base URL of the Mailosaur service.
+        :type base_url: str
+        """
         api_key = api_key or os.environ.get('MAILOSAUR_API_KEY')
 
         if not api_key:

--- a/mailosaur/models/message.py
+++ b/mailosaur/models/message.py
@@ -34,7 +34,7 @@ class Message(object):
     :type attachments: list[~mailosaur.models.Attachment]
     :param metadata:
     :type metadata: ~mailosaur.models.Metadata
-    :param server: Identifier for the server in which the message is located.
+    :param server: Identifier for the inbox (server) in which the message is located.
     :type server: str
     """
 

--- a/mailosaur/models/server.py
+++ b/mailosaur/models/server.py
@@ -1,15 +1,15 @@
 class Server(object):
-    """Server.
+    """A Mailosaur inbox (server) - a virtual SMTP/SMS endpoint.
 
-    :param id: Unique identifier for the server. Used as username for
+    :param id: Unique identifier for the inbox (server). Used as username for
      SMTP/POP3 authentication.
     :type id: str
-    :param name: A name used to identify the server.
+    :param name: A name used to identify the inbox (server).
     :type name: str
     :param users: Users (excluding administrators) who have access to the
-     server.
+     inbox (server) when access is restricted.
     :type users: list[str]
-    :param messages: The number of messages currently in the server.
+    :param messages: The number of messages currently in the inbox (server).
     :type messages: int
     """
 

--- a/mailosaur/models/server_create_options.py
+++ b/mailosaur/models/server_create_options.py
@@ -1,7 +1,7 @@
 class ServerCreateOptions(object):
-    """ServerCreateOptions.
+    """Options used to create a new Mailosaur inbox (server).
 
-    :param name: A name used to identify the server.
+    :param name: A name used to identify the inbox (server).
     :type name: str
     """
 

--- a/mailosaur/models/server_list_result.py
+++ b/mailosaur/models/server_list_result.py
@@ -1,9 +1,9 @@
 class ServerListResult(object):
-    """The result of a server listing request.
+    """The result of an inbox (server) listing request.
 
-    :param items: The individual servers forming the result. Servers are
-     returned sorted by creation date, with the most recently-created server
-     appearing first.
+    :param items: The individual inboxes (servers) forming the result. Inboxes
+     (servers) are returned sorted by creation date, with the most
+     recently-created inbox (server) appearing first.
     :type items: list[~mailosaur.models.Server]
     """
 

--- a/mailosaur/operations/analysis_operations.py
+++ b/mailosaur/operations/analysis_operations.py
@@ -3,7 +3,9 @@ from ..models import MailosaurException
 from ..models import DeliverabilityReport
 
 class AnalysisOperations(object):
-    """AnalysisOperations operations.
+    """Operations for analyzing the content and deliverability of an email, including
+    SpamAssassin scoring and per-provider deliverability reports.
+    Accessed via ``client.analysis``.
     """
 
     def __init__(self, session, base_url, handle_http_error):
@@ -12,16 +14,12 @@ class AnalysisOperations(object):
         self.handle_http_error = handle_http_error
 
     def spam(self, email):
-        """Perform a spam test.
+        """Perform a spam analysis of an email.
 
-        Perform spam testing on the specified email.
-
-        :param email: The identifier of the email to be analyzed.
-        :type email: str        
-        :return: SpamAnalysisResult
+        :param email: The identifier of the message to be analyzed.
+        :type email: str
+        :return: A result containing the spam score and filter results.
         :rtype: ~mailosaur.models.SpamAnalysisResult
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/analysis/spam/%s" % (self.base_url, email)
         response = self.session.get(url)
@@ -35,16 +33,12 @@ class AnalysisOperations(object):
         return SpamAnalysisResult(data)
 
     def deliverability(self, email):
-        """Perform a deliverability test.
+        """Perform a deliverability report of an email.
 
-        Perform deliverability testing on the specified email.
-
-        :param email: The identifier of the email to be analyzed.
-        :type email: str        
-        :return: DeliverabilityReport
+        :param email: The identifier of the message to be analyzed.
+        :type email: str
+        :return: A deliverability report for the email.
         :rtype: ~mailosaur.models.DeliverabilityReport
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/analysis/deliverability/%s" % (self.base_url, email)
         response = self.session.get(url)

--- a/mailosaur/operations/devices_operations.py
+++ b/mailosaur/operations/devices_operations.py
@@ -22,11 +22,11 @@ class DevicesOperations(object):
 
     def generate_email_address(self, server):
         """Generates a random email address by appending a random string in front of
-        the server's domain name.
+        the domain name of the inbox (server).
 
-        :param server: The identifier of the server.
+        :param server: The identifier of the inbox (server).
         :type server: str
-        :return: A random email address ending in the server's domain.
+        :return: A random email address ending in the domain of the inbox (server).
         :rtype: str
         """
         host = os.getenv('MAILOSAUR_SMTP_HOST', 'mailosaur.net')

--- a/mailosaur/operations/devices_operations.py
+++ b/mailosaur/operations/devices_operations.py
@@ -10,7 +10,9 @@ from ..models import MailosaurException
 
 
 class DevicesOperations(object):
-    """DevicesOperations operations.
+    """Operations for managing virtual security devices and retrieving their current
+    one-time passwords (OTPs), used to automate testing of app-based multi-factor
+    authentication. Accessed via ``client.devices``.
     """
 
     def __init__(self, session, base_url, handle_http_error):
@@ -19,20 +21,24 @@ class DevicesOperations(object):
         self.handle_http_error = handle_http_error
 
     def generate_email_address(self, server):
+        """Generates a random email address by appending a random string in front of
+        the server's domain name.
+
+        :param server: The identifier of the server.
+        :type server: str
+        :return: A random email address ending in the server's domain.
+        :rtype: str
+        """
         host = os.getenv('MAILOSAUR_SMTP_HOST', 'mailosaur.net')
         randomString = ''.join(random.choice(
             string.ascii_uppercase + string.digits) for _ in range(10))
         return "%s@%s.%s" % (randomString, server, host)
 
     def list(self):
-        """List all devices.
+        """Returns a list of your virtual security devices.
 
-        Returns a list of your virtual security devices.
-
-        :return: DeviceListResult
+        :return: A result containing your devices.
         :rtype: ~mailosaur.models.DeviceListResult
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/devices" % (self.base_url)
         response = self.session.get(url)
@@ -46,16 +52,12 @@ class DevicesOperations(object):
         return DeviceListResult(data)
 
     def create(self, device_create_options):
-        """Create a device.
+        """Creates a new virtual security device.
 
-        Creates a new virtual security device and returns it.
-
-        :param device_create_options:
+        :param device_create_options: Options used to create a new Mailosaur virtual security device.
         :type device_create_options: ~mailosaur.models.DeviceCreateOptions
-        :return: Device
+        :return: The newly-created device.
         :rtype: ~mailosaur.models.Device
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/devices" % (self.base_url)
         response = self.session.post(url, json=device_create_options.to_json())
@@ -69,17 +71,13 @@ class DevicesOperations(object):
         return Device(data)
 
     def otp(self, query):
-        """Retrieves the current one-time password for a saved device, or given base32-encoded shared secret.
-
-        Retrieves the detail for a single server. Simply supply the unique
-        identifier for the required server.
+        """Retrieves the current one-time password for a saved device, or given
+        base32-encoded shared secret.
 
         :param query: Either the unique identifier of the device, or a base32-encoded shared secret.
-        :type query: str        
-        :return: OtpResult
+        :type query: str
+        :return: A result containing the current one-time password.
         :rtype: ~mailosaur.models.OtpResult
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         if "-" in query:
             url = "%sapi/devices/%s/otp" % (self.base_url, query)
@@ -106,16 +104,14 @@ class DevicesOperations(object):
 
     def delete(
             self, id):
-        """Delete a device.
+        """Permanently delete a virtual security device.
 
-        Permanently delete a virtual security device. This operation cannot be undone.
+        This operation cannot be undone.
 
-        :param id: The identifier of the device to be deleted.
-        :type id: str        
+        :param id: The unique identifier of the device.
+        :type id: str
         :return: None
         :rtype: None
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/devices/%s" % (self.base_url, id)
         response = self.session.delete(url)

--- a/mailosaur/operations/files_operations.py
+++ b/mailosaur/operations/files_operations.py
@@ -4,7 +4,9 @@ from datetime import datetime
 
 
 class FilesOperations(object):
-    """FilesOperations operations.
+    """Operations for downloading the raw content associated with a message - file
+    attachments, the full EML source of an email, and rendered email previews.
+    Accessed via ``client.files``.
     """
 
     def __init__(self, session, base_url, handle_http_error):
@@ -13,17 +15,12 @@ class FilesOperations(object):
         self.handle_http_error = handle_http_error
 
     def get_attachment(self, id):
-        """Download an attachment.
+        """Downloads a single attachment.
 
-        Downloads a single attachment. Simply supply the unique identifier for
-        the required attachment.
-
-        :param id: The identifier of the attachment to be downloaded.
+        :param id: The identifier for the required attachment.
         :type id: str
-        :return: object
-        :rtype: Generator
-        :raises:
-         :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
+        :return: A streamed response whose body contains the attachment's binary content.
+        :rtype: ~requests.Response
         """
         url = "%sapi/files/attachments/%s" % (self.base_url, id)
         response = self.session.get(url, stream=True)
@@ -35,17 +32,12 @@ class FilesOperations(object):
         return response
 
     def get_email(self, id):
-        """Download EML.
+        """Downloads an EML file representing the specified email.
 
-        Downloads an EML file representing the specified email. Simply supply
-        the unique identifier for the required email.
-
-        :param id: The identifier of the email to be downloaded.
+        :param id: The identifier for the required message.
         :type id: str
-        :return: object
-        :rtype: Generator
-        :raises:
-         :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
+        :return: A streamed response whose body contains the raw EML content of the email.
+        :rtype: ~requests.Response
         """
         url = "%sapi/files/email/%s" % (self.base_url, id)
         response = self.session.get(url, stream=True)
@@ -57,17 +49,17 @@ class FilesOperations(object):
         return response
 
     def get_preview(self, id):
-        """Download an email preview.
+        """Downloads a screenshot of your email rendered in a real email client.
 
-        Downloads a screenshot of your email rendered in a real email client. Simply supply
-        the unique identifier for the required preview.
+        Simply supply the unique identifier for the required preview.
 
         :param id: The identifier of the email preview to be downloaded.
         :type id: str
-        :return: object
-        :rtype: Generator
-        :raises:
-         :class:`HttpOperationError<msrest.exceptions.HttpOperationError>`
+        :return: A streamed response whose body contains the preview screenshot image.
+        :rtype: ~requests.Response
+        :raises: :class:`MailosaurException<mailosaur.models.MailosaurException>`
+         with error type ``preview_timeout`` if the preview is not generated
+         within the time limit.
         """
         timeout = 120000
         poll_count = 0

--- a/mailosaur/operations/messages_operations.py
+++ b/mailosaur/operations/messages_operations.py
@@ -8,7 +8,7 @@ from ..models import MailosaurException
 
 class MessagesOperations(object):
     """Operations for finding, retrieving, creating, forwarding, replying to, and
-    deleting the email and SMS messages received by your Mailosaur servers.
+    deleting the email and SMS messages received by your Mailosaur inboxes (servers).
     Accessed via ``client.messages``.
     """
 
@@ -24,7 +24,7 @@ class MessagesOperations(object):
         **Recommended:** This is the most efficient method of looking up a message,
         therefore we recommend using it wherever possible.
 
-        :param server: The unique identifier of the containing server.
+        :param server: The unique identifier of the containing inbox (server).
         :type server: str
         :param criteria: The criteria with which to find messages during a search.
         :type criteria: ~mailosaur.models.SearchCriteria
@@ -96,7 +96,7 @@ class MessagesOperations(object):
         The summaries are returned sorted by received date, with the most
         recently-received messages appearing first.
 
-        :param server: The unique identifier of the required server.
+        :param server: The unique identifier of the required inbox (server).
         :type server: str
         :param page: Used in conjunction with `itemsPerPage` to support
          pagination.
@@ -130,11 +130,11 @@ class MessagesOperations(object):
         return MessageListResult(data)
 
     def delete_all(self, server):
-        """Permanently delete all messages within a server.
+        """Permanently delete all messages within an inbox (server).
 
         This operation cannot be undone.
 
-        :param server: The unique identifier of the server.
+        :param server: The unique identifier of the inbox (server).
         :type server: str
         :return: None
         :rtype: None
@@ -153,7 +153,7 @@ class MessagesOperations(object):
         The messages are returned sorted by received date, with the most
         recently-received messages appearing first.
 
-        :param server: The unique identifier of the server to search.
+        :param server: The unique identifier of the inbox (server) to search.
         :type server: str
         :param criteria: The criteria with which to find messages during a search.
         :type criteria: ~mailosaur.models.SearchCriteria
@@ -231,7 +231,7 @@ class MessagesOperations(object):
         This is useful in scenarios where you want an email to trigger a workflow
         in your product.
 
-        :param server: The unique identifier of the required server.
+        :param server: The unique identifier of the required inbox (server).
         :type server: str
         :param options: Options to use when creating a new message.
         :type options: ~mailosaur.models.MessageCreateOptions

--- a/mailosaur/operations/messages_operations.py
+++ b/mailosaur/operations/messages_operations.py
@@ -7,7 +7,9 @@ from ..models import MailosaurException
 
 
 class MessagesOperations(object):
-    """MessagesOperations operations.
+    """Operations for finding, retrieving, creating, forwarding, replying to, and
+    deleting the email and SMS messages received by your Mailosaur servers.
+    Accessed via ``client.messages``.
     """
 
     def __init__(self, session, base_url, handle_http_error):
@@ -16,15 +18,16 @@ class MessagesOperations(object):
         self.handle_http_error = handle_http_error
 
     def get(self, server, criteria, timeout=10000, received_after=(datetime.today() - timedelta(hours=1)), dir=None):
-        """Retrieve a message using search criteria.
+        """Waits for a message to be found, returning as soon as a message matching the
+        specified search criteria is found.
 
-        Returns as soon as a message matching the specified search criteria is
-        found. This is the most efficient method of looking up a message.
+        **Recommended:** This is the most efficient method of looking up a message,
+        therefore we recommend using it wherever possible.
 
-        :param server: The identifier of the server hosting the message.
+        :param server: The unique identifier of the containing server.
         :type server: str
-        :param criteria: The search criteria to use in order to find a match.
-        :type criteria: ~mailosaur.models.SearchCriteria      
+        :param criteria: The criteria with which to find messages during a search.
+        :type criteria: ~mailosaur.models.SearchCriteria
         :param timeout: Specify how long to wait for a matching result (in milliseconds).
         :type timeout: int
         :param received_after: Limits results to only messages received after this date/time.
@@ -32,10 +35,11 @@ class MessagesOperations(object):
         :param dir: Optionally limits results based on the direction (`Sent` or `Received`),
          with the default being `Received`.
         :type dir: str
-        :return: Message
+        :return: The first message matching the criteria.
         :rtype: ~mailosaur.models.Message
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
+        :raises: :class:`MailosaurException<mailosaur.models.MailosaurException>`
+         with error type ``no_messages_found`` if no matching message exists, or
+         ``search_timeout`` if no matching message arrives before the timeout elapses.
         """
         # Defaults timeout to 10s, receivedAfter to 1h
         if len(server) != 8:
@@ -47,17 +51,15 @@ class MessagesOperations(object):
         return self.get_by_id(result.items[0].id)
 
     def get_by_id(self, id):
-        """Retrieve a message.
+        """Retrieves the detail for a single message.
 
-        Retrieves the detail for a single email message. Simply supply the
+        Must be used in conjunction with either list or search in order to get the
         unique identifier for the required message.
 
-        :param id: The identifier of the email message to be retrieved.
-        :type id: str        
-        :return: Message
+        :param id: The unique identifier of the message to be retrieved.
+        :type id: str
+        :return: The full message.
         :rtype: ~mailosaur.models.Message
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/messages/%s" % (self.base_url, id)
         response = self.session.get(url)
@@ -71,17 +73,15 @@ class MessagesOperations(object):
         return Message(data)
 
     def delete(self, id):
-        """Delete a message.
+        """Permanently deletes a message.
 
-        Permanently deletes a message. This operation cannot be undone. Also
-        deletes any attachments related to the message.
+        Also deletes any attachments related to the message. This operation cannot
+        be undone.
 
-        :param id: The identifier of the message to be deleted.
-        :type id: str        
+        :param id: The identifier for the message.
+        :type id: str
         :return: None
         :rtype: None
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/messages/%s" % (self.base_url, id)
         response = self.session.delete(url)
@@ -91,29 +91,26 @@ class MessagesOperations(object):
             return
 
     def list(self, server, page=None, items_per_page=None, received_after=None, dir=None):
-        """List all messages.
+        """Returns a list of your messages in summary form.
 
-        Returns a list of your messages in summary form. The summaries are
-        returned sorted by received date, with the most recently-received
-        messages appearing first.
+        The summaries are returned sorted by received date, with the most
+        recently-received messages appearing first.
 
-        :param server: The identifier of the server hosting the messages.
+        :param server: The unique identifier of the required server.
         :type server: str
         :param page: Used in conjunction with `itemsPerPage` to support
          pagination.
         :type page: int
         :param items_per_page: A limit on the number of results to be returned
          per page. Can be set between 1 and 1000 items, the default is 50.
-        :type items_per_page: int   
+        :type items_per_page: int
         :param received_after: Limits results to only messages received after this date/time.
         :type received_after: datetime
         :param dir: Optionally limits results based on the direction (`Sent` or `Received`),
          with the default being `Received`.
         :type dir: str
-        :return: MessageListResult
+        :return: A result containing the message summaries.
         :rtype: ~mailosaur.models.MessageListResult
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/messages" % (self.base_url)
 
@@ -133,18 +130,14 @@ class MessagesOperations(object):
         return MessageListResult(data)
 
     def delete_all(self, server):
-        """Delete all messages.
+        """Permanently delete all messages within a server.
 
-        Permanently deletes all messages held by the specified server. This
-        operation cannot be undone. Also deletes any attachments related to
-        each message.
+        This operation cannot be undone.
 
-        :param server: The identifier of the server to be emptied.
-        :type server: str        
+        :param server: The unique identifier of the server.
+        :type server: str
         :return: None
         :rtype: None
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/messages" % (self.base_url)
         params = {'server': server}
@@ -155,15 +148,14 @@ class MessagesOperations(object):
             return
 
     def search(self, server, criteria, page=None, items_per_page=None, timeout=None, received_after=None, error_on_timeout=True, dir=None):
-        """Search for messages.
+        """Returns a list of messages matching the specified search criteria, in summary form.
 
-        Returns a list of messages matching the specified search criteria, in
-        summary form. The messages are returned sorted by received date, with
-        the most recently-received messages appearing first.
+        The messages are returned sorted by received date, with the most
+        recently-received messages appearing first.
 
-        :param server: The identifier of the server hosting the messages.
+        :param server: The unique identifier of the server to search.
         :type server: str
-        :param criteria: The search criteria to match results against.
+        :param criteria: The criteria with which to find messages during a search.
         :type criteria: ~mailosaur.models.SearchCriteria
         :param page: Used in conjunction with `itemsPerPage` to support
          pagination.
@@ -175,16 +167,17 @@ class MessagesOperations(object):
         :type timeout: int
         :param received_after: Limits results to only messages received after this date/time.
         :type received_after: datetime
-        :param error_on_timeout: When set to false, an error will not be throw if timeout 
+        :param error_on_timeout: When set to false, an error will not be thrown if timeout
          is reached (default: true).
         :type error_on_timeout: bool
         :param dir: Optionally limits results based on the direction (`Sent` or `Received`),
          with the default being `Received`.
         :type dir: str
-        :return: MessageListResult
+        :return: A result containing the matching message summaries.
         :rtype: ~mailosaur.models.MessageListResult
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
+        :raises: :class:`MailosaurException<mailosaur.models.MailosaurException>`
+         with error type ``search_timeout`` if no matching message is found before
+         the timeout elapses, unless ``error_on_timeout`` is set to false.
         """
         url = "%sapi/messages/search" % (self.base_url)
 
@@ -233,20 +226,17 @@ class MessagesOperations(object):
             time.sleep(delay / 1000)
 
     def create(self, server, options):
-        """Create a message.
+        """Creates a new message that can be sent to a verified email address.
 
-        Creates a new message that can be sent to a verified email address. This is
-        useful in scenarios where you want an email to trigger a workflow in your
-        product
+        This is useful in scenarios where you want an email to trigger a workflow
+        in your product.
 
-        :param server: The identifier of the server to create the message in.
+        :param server: The unique identifier of the required server.
         :type server: str
-        :param options: The options with which to create the message.
+        :param options: Options to use when creating a new message.
         :type options: ~mailosaur.models.MessageCreateOptions
-        :return: None
-        :rtype: None
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
+        :return: The newly-created message.
+        :rtype: ~mailosaur.models.Message
         """
         url = "%sapi/messages" % (self.base_url)
         params = {'server': server}
@@ -262,18 +252,16 @@ class MessagesOperations(object):
         return Message(data)
 
     def forward(self, id, options):
-        """Forward an email.
+        """Forwards the specified message to a verified email address.
 
-        Forwards the specified email to a verified email address.
+        This is useful for simulating a user forwarding one of your email messages.
 
-        :param id: The identifier of the email to forward.
+        :param id: The unique identifier of the message to be forwarded.
         :type id: str
-        :param options: The options with which to forward the email.
+        :param options: Options to use when forwarding a message.
         :type options: ~mailosaur.models.MessageForwardOptions
-        :return: None
-        :rtype: None
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
+        :return: The forwarded message.
+        :rtype: ~mailosaur.models.Message
         """
         url = "%sapi/messages/%s/forward" % (self.base_url, id)
         response = self.session.post(url, json=options.to_json())
@@ -287,19 +275,17 @@ class MessagesOperations(object):
         return Message(data)
 
     def reply(self, id, options):
-        """Reply to an email.
+        """Sends a reply to the specified message.
 
-        Sends a reply to the specified email. This is useful for when simulating a user
-        replying to one of your emails.
+        This is useful for when simulating a user replying to one of your email
+        or SMS messages.
 
-        :param id: The identifier of the email to reply to.
+        :param id: The unique identifier of the message to be replied to.
         :type id: str
-        :param options: The options with which to reply to the email.
+        :param options: Options to use when replying to a message.
         :type options: ~mailosaur.models.MessageReplyOptions
-        :return: None
-        :rtype: None
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
+        :return: The reply message.
+        :rtype: ~mailosaur.models.Message
         """
         url = "%sapi/messages/%s/reply" % (self.base_url, id)
         response = self.session.post(url, json=options.to_json())
@@ -313,18 +299,14 @@ class MessagesOperations(object):
         return Message(data)
 
     def generate_previews(self, id, options):
-        """Generate email previews.
-
-        Generates screenshots of an email rendered in the specified email clients.
+        """Generates screenshots of an email rendered in the specified email clients.
 
         :param id: The identifier of the email to preview.
         :type id: str
         :param options: The options with which to generate previews.
         :type options: ~mailosaur.models.PreviewRequestOptions
-        :return: PreviewListResult
+        :return: A result containing the generated previews.
         :rtype: ~mailosaur.models.PreviewListResult
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/messages/%s/screenshots" % (self.base_url, id)
         response = self.session.post(url, json=options.to_json())

--- a/mailosaur/operations/previews_operations.py
+++ b/mailosaur/operations/previews_operations.py
@@ -2,7 +2,9 @@ from ..models import EmailClientListResult
 
 
 class PreviewsOperations(object):
-    """PreviewsOperations operations.
+    """Operations for discovering the email clients available for generating email
+    previews (screenshots of an email rendered in real clients).
+    Accessed via ``client.previews``.
     """
 
     def __init__(self, session, base_url, handle_http_error):
@@ -13,12 +15,8 @@ class PreviewsOperations(object):
     def list_email_clients(self):
         """List all email clients that can be used to generate email previews.
 
-        Returns a list of available email clients.
-
-        :return: EmailClientListResult
+        :return: A result containing the available email clients.
         :rtype: ~mailosaur.models.EmailClientListResult
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/screenshots/clients" % (self.base_url)
         response = self.session.get(url)

--- a/mailosaur/operations/servers_operations.py
+++ b/mailosaur/operations/servers_operations.py
@@ -6,8 +6,8 @@ from ..models import Server
 from ..models import MailosaurException
 
 class ServersOperations(object):
-    """Operations for creating and managing your Mailosaur servers - the virtual
-    inboxes that group your tests together, each with its own domain and
+    """Operations for creating and managing your Mailosaur inboxes (servers) - they
+    group your tests together, each with its own domain and
     SMTP/POP3/IMAP credentials. Accessed via ``client.servers``.
     """
 
@@ -18,11 +18,11 @@ class ServersOperations(object):
 
     def generate_email_address(self, server):
         """Generates a random email address by appending a random string in front of
-        the server's domain name.
+        the domain name of the inbox (server).
 
-        :param server: The identifier of the server.
+        :param server: The identifier of the inbox (server).
         :type server: str
-        :return: A random email address ending in the server's domain.
+        :return: A random email address ending in the domain of the inbox (server).
         :rtype: str
         """
         host = os.getenv('MAILOSAUR_SMTP_HOST', 'mailosaur.net')
@@ -30,11 +30,11 @@ class ServersOperations(object):
         return "%s@%s.%s" % (randomString, server, host)
 
     def list(self):
-        """Returns a list of your virtual servers.
+        """Returns a list of your inboxes (servers).
 
-        Servers are returned sorted in alphabetical order.
+        Inboxes (servers) are returned sorted in alphabetical order.
 
-        :return: A result containing your servers.
+        :return: A result containing your inboxes (servers).
         :rtype: ~mailosaur.models.ServerListResult
         """
         url = "%sapi/servers" % (self.base_url)
@@ -49,11 +49,11 @@ class ServersOperations(object):
         return ServerListResult(data)
 
     def create(self, server_create_options):
-        """Creates a new virtual server.
+        """Creates a new inbox (server).
 
-        :param server_create_options: Options used to create a new Mailosaur server.
+        :param server_create_options: Options used to create a new Mailosaur inbox (server).
         :type server_create_options: ~mailosaur.models.ServerCreateOptions
-        :return: The newly-created server.
+        :return: The newly-created inbox (server).
         :rtype: ~mailosaur.models.Server
         """
         url = "%sapi/servers" % (self.base_url)
@@ -68,11 +68,11 @@ class ServersOperations(object):
         return Server(data)
 
     def get(self, id):
-        """Retrieves the detail for a single server.
+        """Retrieves the detail for a single inbox (server).
 
-        :param id: The unique identifier of the server.
+        :param id: The unique identifier of the inbox (server).
         :type id: str
-        :return: The server.
+        :return: The inbox (server).
         :rtype: ~mailosaur.models.Server
         """
         url = "%sapi/servers/%s" % (self.base_url, id)
@@ -87,13 +87,13 @@ class ServersOperations(object):
         return Server(data)
 
     def get_password(self, id):
-        """Retrieves the password for a server.
+        """Retrieves the password for an inbox (server).
 
         This password can be used for SMTP, POP3, and IMAP connectivity.
 
-        :param id: The unique identifier of the server.
+        :param id: The unique identifier of the inbox (server).
         :type id: str
-        :return: The server's password.
+        :return: The password for the inbox (server).
         :rtype: str
         """
         url = "%sapi/servers/%s/password" % (self.base_url, id)
@@ -109,13 +109,13 @@ class ServersOperations(object):
 
     def update(
             self, id, server):
-        """Updates the attributes of a server.
+        """Updates the attributes of an inbox (server).
 
-        :param id: The unique identifier of the server.
+        :param id: The unique identifier of the inbox (server).
         :type id: str
-        :param server: The updated server.
+        :param server: The updated inbox (server).
         :type server: ~mailosaur.models.Server
-        :return: The updated server.
+        :return: The updated inbox (server).
         :rtype: ~mailosaur.models.Server
         """
         url = "%sapi/servers/%s" % (self.base_url, id)
@@ -131,12 +131,12 @@ class ServersOperations(object):
 
     def delete(
             self, id):
-        """Permanently delete a server.
+        """Permanently delete an inbox (server).
 
         This will also delete all messages, associated attachments, etc. within
-        the server. This operation cannot be undone.
+        the inbox (server). This operation cannot be undone.
 
-        :param id: The unique identifier of the server.
+        :param id: The unique identifier of the inbox (server).
         :type id: str
         :return: None
         :rtype: None

--- a/mailosaur/operations/servers_operations.py
+++ b/mailosaur/operations/servers_operations.py
@@ -6,7 +6,9 @@ from ..models import Server
 from ..models import MailosaurException
 
 class ServersOperations(object):
-    """ServersOperations operations.
+    """Operations for creating and managing your Mailosaur servers - the virtual
+    inboxes that group your tests together, each with its own domain and
+    SMTP/POP3/IMAP credentials. Accessed via ``client.servers``.
     """
 
     def __init__(self, session, base_url, handle_http_error):
@@ -15,20 +17,25 @@ class ServersOperations(object):
         self.handle_http_error = handle_http_error
 
     def generate_email_address(self, server):
+        """Generates a random email address by appending a random string in front of
+        the server's domain name.
+
+        :param server: The identifier of the server.
+        :type server: str
+        :return: A random email address ending in the server's domain.
+        :rtype: str
+        """
         host = os.getenv('MAILOSAUR_SMTP_HOST', 'mailosaur.net')
         randomString = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
         return "%s@%s.%s" % (randomString, server, host)
 
     def list(self):
-        """List all servers.
+        """Returns a list of your virtual servers.
 
-        Returns a list of your virtual SMTP servers. Servers are returned
-        sorted in alphabetical order.
+        Servers are returned sorted in alphabetical order.
 
-        :return: ServerListResult
+        :return: A result containing your servers.
         :rtype: ~mailosaur.models.ServerListResult
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/servers" % (self.base_url)
         response = self.session.get(url)
@@ -42,16 +49,12 @@ class ServersOperations(object):
         return ServerListResult(data)
 
     def create(self, server_create_options):
-        """Create a server.
+        """Creates a new virtual server.
 
-        Creates a new virtual SMTP server and returns it.
-
-        :param server_create_options:
+        :param server_create_options: Options used to create a new Mailosaur server.
         :type server_create_options: ~mailosaur.models.ServerCreateOptions
-        :return: Server
+        :return: The newly-created server.
         :rtype: ~mailosaur.models.Server
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/servers" % (self.base_url)
         response = self.session.post(url, json=server_create_options.to_json())
@@ -65,17 +68,12 @@ class ServersOperations(object):
         return Server(data)
 
     def get(self, id):
-        """Retrieve a server.
+        """Retrieves the detail for a single server.
 
-        Retrieves the detail for a single server. Simply supply the unique
-        identifier for the required server.
-
-        :param id: The identifier of the server to be retrieved.
-        :type id: str        
-        :return: Server
+        :param id: The unique identifier of the server.
+        :type id: str
+        :return: The server.
         :rtype: ~mailosaur.models.Server
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/servers/%s" % (self.base_url, id)
         response = self.session.get(url)
@@ -89,17 +87,14 @@ class ServersOperations(object):
         return Server(data)
 
     def get_password(self, id):
-        """Retrieve server password.
+        """Retrieves the password for a server.
 
-        Retrieves the password for use with SMTP and POP3 for a single server. 
-        Simply supply the unique identifier for the required server.
+        This password can be used for SMTP, POP3, and IMAP connectivity.
 
-        :param id: The identifier of the server.
+        :param id: The unique identifier of the server.
         :type id: str
-        :return: str
+        :return: The server's password.
         :rtype: str
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/servers/%s/password" % (self.base_url, id)
         response = self.session.get(url)
@@ -114,19 +109,14 @@ class ServersOperations(object):
 
     def update(
             self, id, server):
-        """Update a server.
+        """Updates the attributes of a server.
 
-        Updats a single server and returns it.
-
-        :param id: The identifier of the server to be updated.
+        :param id: The unique identifier of the server.
         :type id: str
-        :param server:
+        :param server: The updated server.
         :type server: ~mailosaur.models.Server
-        :param dict custom_headers: headers that will be added to the request
-        :return: Server
+        :return: The updated server.
         :rtype: ~mailosaur.models.Server
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/servers/%s" % (self.base_url, id)
         response = self.session.put(url, json=server.to_json())
@@ -141,17 +131,15 @@ class ServersOperations(object):
 
     def delete(
             self, id):
-        """Delete a server.
+        """Permanently delete a server.
 
-        Permanently deletes a server. This operation cannot be undone. Also
-        deletes all messages and associated attachments within the server.
+        This will also delete all messages, associated attachments, etc. within
+        the server. This operation cannot be undone.
 
-        :param id: The identifier of the server to be deleted.
-        :type id: str        
+        :param id: The unique identifier of the server.
+        :type id: str
         :return: None
         :rtype: None
-        :raises:
-         :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/servers/%s" % (self.base_url, id)
         response = self.session.delete(url)

--- a/mailosaur/operations/usage_operations.py
+++ b/mailosaur/operations/usage_operations.py
@@ -3,7 +3,9 @@ from ..models import UsageTransactionListResult
 from ..models import MailosaurException
 
 class UsageOperations(object):
-    """UsageOperations operations.
+    """Operations for inspecting your account's usage limits and recent transactional
+    usage. These endpoints require authentication with an account-level API key.
+    Accessed via ``client.usage``.
     """
 
     def __init__(self, session, base_url, handle_http_error):
@@ -14,12 +16,11 @@ class UsageOperations(object):
     def limits(self):
         """Retrieve account usage limits.
 
-        Details the current limits and usage for your account.
+        Details the current limits and usage for your account. This endpoint
+        requires authentication with an account-level API key.
 
-        :return: UsageAccountLimits
+        :return: The usage limits for your account.
         :rtype: ~mailosaur.models.UsageAccountLimits
-        :raises:
-        :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/usage/limits" % (self.base_url)
         response = self.session.get(url)
@@ -35,12 +36,10 @@ class UsageOperations(object):
     def transactions(self):
         """Retrieves the last 31 days of transactional usage.
 
-        Details the usage transactions processed by Mailosaur in the last 31 days.
+        This endpoint requires authentication with an account-level API key.
 
-        :return: UsageTransactionListResult
+        :return: The transactional usage for the last 31 days.
         :rtype: ~mailosaur.models.UsageTransactionListResult
-        :raises:
-        :class:`MailosaurException<mailosaur.models.MailosaurException>`
         """
         url = "%sapi/usage/transactions" % (self.base_url)
         response = self.session.get(url)


### PR DESCRIPTION
## Summary

- Add and expand Intellisense doc comments across the client and operations classes (descriptions, parameters, and return values).
- Adopt **inbox (server)** terminology in the doc-comment prose, so hover documentation matches the dashboard UI.

## Scope

- Doc comments only — no code, public API, or behaviour changes.
- Parameter names, type names, and other code identifiers are unchanged.
